### PR TITLE
Deleted getTransactionById method's result check

### DIFF
--- a/src/Models/Invoice.php
+++ b/src/Models/Invoice.php
@@ -85,9 +85,6 @@ class Invoice extends Model
 
         $transaction = TransactionService::getTransactionById($transaction_id);
 
-        if (is_null($transaction))
-            throw new \Exception("Transaction not found!");
-
         if ($transaction->state == Transaction::STATE_COMPLETED)
         {
             if ($transaction->amount == $this->amount)


### PR DESCRIPTION
Now it is not necessary to check if transaction exists or does not. getTransactioById method already throws an exception if transaction doesnt exist. All we need is to just handle this exception when we call PAY method.