### PR TITLE
Fix DataFormat::timestamp2datetime returning 1970 for numeric timestamps (addresses #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ All notable changes to `pay-uz` will be documented in this file
 
 ### Fixed
 
+- **`DataFormat::timestamp2datetime()` returned `1970-01-01` for numeric timestamps.**
+  It applied `strtotime()` to the numeric Unix timestamp (which returns `false`),
+  so any numeric input collapsed to the epoch. It now accepts both a numeric Unix
+  timestamp (used by Uzcard) and a date-time string (Click `sign_time`, Paynet
+  `transactionTime`). `datetime2timestamp()` is hardened symmetrically. (Addresses
+  the bug behind #68; the `getReport` part of #68 was already fixed by #69.)
 - **Octane / RoadRunner request body (#71).** All gateways now read the request
   body via `request()->getContent()` instead of `file_get_contents('php://input')`,
   which is unreliable under Octane/RoadRunner.

--- a/src/Http/Classes/DataFormat.php
+++ b/src/Http/Classes/DataFormat.php
@@ -78,19 +78,29 @@ class DataFormat{
             $timestamp = self::timestamp2seconds($timestamp);
         }
 
+        // Accept either a numeric Unix timestamp (seconds) or a parseable
+        // date-time string. strtotime() must only be applied to a string —
+        // calling it on a numeric timestamp returns false, which previously
+        // made this method yield "1970-01-01 00:00:00" for every numeric input.
+        if (!is_numeric($timestamp)) {
+            $timestamp = strtotime($timestamp);
+        }
+
         // convert to datetime string
-        return date('Y-m-d H:i:s', strtotime($timestamp));
+        return date('Y-m-d H:i:s', (int) $timestamp);
     }
 
     /**
      * Converts date time string to timestamp value.
-     * @param string $datetime date time string.
+     * @param string|int $datetime date time string or Unix timestamp.
      * @return int timestamp as seconds.
      */
     public static function datetime2timestamp($datetime)
     {
         if ($datetime) {
-            return strtotime($datetime);
+            // A date-time string is parsed with strtotime(); an already numeric
+            // Unix timestamp is returned as-is (strtotime() of a number is false).
+            return is_numeric($datetime) ? (int) $datetime : strtotime($datetime);
         }
 
         return $datetime;

--- a/tests/DataFormatTest.php
+++ b/tests/DataFormatTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Goodoneuz\PayUz\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Goodoneuz\PayUz\Http\Classes\DataFormat;
+
+/**
+ * Regression tests for DataFormat time conversions.
+ *
+ * `timestamp2datetime()` is called with a numeric Unix timestamp (e.g. Uzcard's
+ * create_time) and with a date-time string (Click sign_time, Paynet
+ * transactionTime); both must work. Previously a numeric input was passed through
+ * strtotime() and collapsed to 1970-01-01.
+ */
+class DataFormatTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        date_default_timezone_set('UTC');
+    }
+
+    /** @test */
+    public function timestamp2datetime_handles_numeric_unix_seconds()
+    {
+        $this->assertSame('2024-06-20 18:53:20', DataFormat::timestamp2datetime(1718909600));
+    }
+
+    /** @test */
+    public function timestamp2datetime_handles_numeric_milliseconds()
+    {
+        // 13-digit ms is normalised to seconds first, then formatted.
+        $this->assertSame('2024-06-20 18:53:20', DataFormat::timestamp2datetime(1718909600000));
+    }
+
+    /** @test */
+    public function timestamp2datetime_still_handles_datetime_strings()
+    {
+        // Click sends sign_time as a 'Y-m-d H:i:s' string — must round-trip unchanged.
+        $this->assertSame('2019-02-15 14:30:00', DataFormat::timestamp2datetime('2019-02-15 14:30:00'));
+    }
+
+    /** @test */
+    public function timestamp2datetime_no_longer_returns_epoch_for_numeric_input()
+    {
+        $this->assertStringStartsNotWith('1970-01-01', DataFormat::timestamp2datetime(1718909600));
+    }
+
+    /** @test */
+    public function datetime2timestamp_parses_strings_and_passes_through_numbers()
+    {
+        $this->assertSame(1550241000, DataFormat::datetime2timestamp('2019-02-15 14:30:00'));
+        $this->assertSame(1718909600, DataFormat::datetime2timestamp(1718909600));
+        // Falsy input is returned unchanged.
+        $this->assertSame(0, DataFormat::datetime2timestamp(0));
+    }
+}


### PR DESCRIPTION
Studies the problem behind **#68** and fixes it correctly.

## The real bug
`DataFormat::timestamp2datetime()` did `date('Y-m-d H:i:s', strtotime($timestamp))`. `strtotime()` expects a **date-time string** — given a **numeric** Unix timestamp it returns `false`, so the result collapsed to the epoch. Proven on `master`:

```
timestamp2datetime(1718909600)      -> 1970-01-01 06:00:00   ❌  (numeric seconds)
timestamp2datetime(1718909600000)   -> 1970-01-01 06:00:00   ❌  (numeric ms)
timestamp2datetime("2019-02-15 …")  -> 2019-02-15 14:30:00   ✓   (string)
```

The method is called both ways across the package:
- **numeric** Unix timestamp — Uzcard `create_time` (`DataFormat::timestamp(true)`);
- **date-time string** — Click `sign_time` (`Click.php`), Paynet `transactionTime` (`Paynet.php`), Oson.

## Why not just merge #68
#68 changed the body to `date('Y-m-d H:i:s', $timestamp)` (drops `strtotime`). That fixes the numeric case but **breaks the string callers** — `date()` with a string second argument also yields 1970. #68 also bundles `getReport` edits that were already superseded by the merged **#69**, and its diff contains a syntax error (`... : null,,`).

## This fix
Apply `strtotime()` **only** to non-numeric input, and format the numeric timestamp directly — so both shapes work:

```
timestamp2datetime(1718909600)      -> 2024-06-20 18:53:20   ✓
timestamp2datetime(1718909600000)   -> 2024-06-20 18:53:20   ✓
timestamp2datetime("2019-02-15 …")  -> 2019-02-15 14:30:00   ✓
```

`datetime2timestamp()` is hardened symmetrically (numeric passes through; strings go via `strtotime`).

Adds `tests/DataFormatTest.php` (numeric seconds / ms / string). Full suite: 11 tests, 34 assertions, green.

Recommend closing **#68** as superseded (its `getReport` part landed via #69; its `DataFormat` part is corrected here without breaking the string callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)