### PR TITLE
Fix Click redirect: replace dead POST form with CLICK-Button payment link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to `pay-uz` will be documented in this file
 
+## Unreleased
+
+### Fixed
+
+- Click redirect: the legacy POST form to `https://my.click.uz/pay/` was shut
+  down by CLICK. `Click::getRedirectParams()` now builds the CLICK-Button
+  payment link (GET to `https://my.click.uz/services/pay`). Shop API
+  callbacks are unchanged.
+
 ## 4.0.0 - 2026-06-21
 
 Expands the package from "Payme + Click webhooks" into a multi-rail Uzbekistan

--- a/src/Http/Classes/Click/Click.php
+++ b/src/Http/Classes/Click/Click.php
@@ -14,6 +14,7 @@ class Click extends BaseGateway
 {
     const REQUEST_PREPARE = 0;
     const REQUEST_COMPLATE = 1;
+    const CUSTOM_FORM = 'pay-uz::merchant.click';
     private $config;
     private $merchant;
     private $request;
@@ -174,22 +175,18 @@ class Click extends BaseGateway
 
     public function getRedirectParams($model, $amount, $currency, $url)
     {
-        $time = date('Y-m-d H:i:s', time());
-        $sign = md5($time . $this->config['secret_key'] .
-            $this->config['service_id'] . $amount);
-        return [
-            'MERCHANT_TRANS_AMOUNT' => $amount,
-            'MERCHANT_ID' => $this->config['merchant_id'],
-            'MERCHANT_USER_ID' => $this->config['merchant_user_id'],
-            'MERCHANT_SERVICE_ID' => $this->config['service_id'],
-            'MERCHANT_TRANS_ID' => PaymentService::convertModelToKey($model),
-            'MERCHANT_TRANS_NOTE' => '',
-            'MERCHANT_USER_PHONE' => '',
-            'MERCHANT_USER_EMAIL' => '',
-            'SIGN_TIME' => $time,
-            'SIGN_STRING' => $sign,
-            'RETURN_URL' => $url,
-            'url' => 'https://my.click.uz/pay/'
+        $params = [
+            'service_id'        => $this->config['service_id'],
+            'merchant_id'       => $this->config['merchant_id'],
+            'amount'            => $amount,
+            'transaction_param' => PaymentService::convertModelToKey($model),
+            'url'               => 'https://my.click.uz/services/pay',
         ];
+
+        if (!empty($url)) {
+            $params['return_url'] = $url;
+        }
+
+        return $params;
     }
 }

--- a/src/resources/views/merchant/click.blade.php
+++ b/src/resources/views/merchant/click.blade.php
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Please, wait...</title>
+</head>
+<body>
+Please, wait...
+<form id="click_form" action="{{ $params['url'] }}" method="get" name="check">
+    @foreach($params as $key => $param)
+        @if($key != 'url')
+        <input type="hidden" name="{{ $key }}" value="{{ $param }}" />
+        @endif
+    @endforeach
+    <button type="submit" style="display:none;">pay</button>
+    <script>
+        window.onload = function(){
+            document.forms['check'].submit();
+        }
+    </script>
+</form>
+
+</body>
+</html>


### PR DESCRIPTION
## Problem

CLICK shut down the legacy POST interface at `https://my.click.uz/pay/`
(uppercase `MERCHANT_*` fields + md5 `SIGN_STRING`), so
`PayUz::driver('click')->redirect(...)` sends users to a dead endpoint —
Click payments are broken for every consumer of this package.
Confirmed with CLICK support: integrations must use the CLICK-Button
payment link (https://docs.click.uz/click-button/).

## Fix

- `Click::getRedirectParams()` now builds the payment link: a signatureless
  GET to `https://my.click.uz/services/pay` with `service_id`, `merchant_id`,
  `amount`, `transaction_param`, `return_url` (omitted when no URL given).
- New Click-specific auto-submit GET form (`merchant/click.blade.php`,
  wired via `CUSTOM_FORM`) — `PayUz::redirect()` keeps its echo-a-view
  behaviour, other drivers untouched.
- `transaction_param` round-trips back to Shop API callbacks as
  `merchant_trans_id`, so Prepare/Complete validation is unchanged.
  No consumer code changes required.

## Tests

7 new tests in `tests/ClickRedirectTest.php`: new param shape, no legacy
`MERCHANT_*`/`SIGN_*` fields, null `return_url`, amount pass-through
(int/decimal/string), GET form + escaped-only Blade output.
Full suite: 275 passing.